### PR TITLE
Post-release follow-ups → prod: POIForm fixes + admin POI-list outage fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,12 @@ Internet → Cloudflare (HTTPS) → ALB (HTTP port 80) → ECS Fargate
            1 vCPU / 3GB                  0.5 vCPU / 1GB
            1 container                   2 containers (nginx + backend)
                     └───────────────┬───────────────┘
+                                    │  both reach (Service Connect, private):
+                                    ▼  http://embedding:80/v1   — no ALB
+                       nearbynearby-prod-embedding service
+                       1 vCPU / 3GB — llama.cpp serving EmbeddingGemma
+                       Q8_0 GGUF via an OpenAI-compatible /v1/embeddings API
+                                    │
                               RDS PostgreSQL (existing, via VPC peering)
                               S3 + CloudFront (existing)
 ```
@@ -323,24 +329,28 @@ All AWS infrastructure is managed in `terraform/`:
 - **Modules used**: networking, ecr, ecs, alb, secrets, monitoring
 - **Not used in prod**: database, storage (existing RDS and S3 kept as-is)
 - **VPC peering**: ECS VPC (10.0.0.0/16) ↔ Default VPC (172.31.0.0/16) for RDS connectivity
-- **State**: S3 backend with DynamoDB locking
+- **State**: S3 backend. The DynamoDB lock table was removed — run with `-lock=false`.
 
 ```bash
-# Apply infrastructure changes
+# Apply infrastructure changes (prod).
+# MUST use the nn-prod profile or terraform hits the wrong AWS account (403 on the
+# S3 state backend, which has no `profile` set). Lock table is gone → -lock=false.
 cd terraform/environments/prod
-export TF_VAR_database_url="postgresql://..."
-export TF_VAR_forms_database_url="postgresql://..."
-export TF_VAR_secret_key="..."
-terraform plan
-terraform apply
+export AWS_PROFILE=nn-prod AWS_REGION=us-east-1
+export TF_VAR_database_url="$(aws ssm get-parameter --name /nearbynearby/prod/database-url --with-decryption --query Parameter.Value --output text)"
+export TF_VAR_forms_database_url="$(aws ssm get-parameter --name /nearbynearby/prod/forms-database-url --with-decryption --query Parameter.Value --output text)"
+export TF_VAR_secret_key="$(aws ssm get-parameter --name /nearbynearby/prod/secret-key --with-decryption --query Parameter.Value --output text)"
+terraform plan  -lock=false
+terraform apply -lock=false
 ```
 
-### Monthly Cost (~$156)
+### Monthly Cost (~$196)
 
 | Resource | Cost |
 |----------|------|
 | ECS Fargate (app: 1 vCPU/3GB) | ~$73 |
 | ECS Fargate (admin: 0.5 vCPU/1GB) | ~$18 |
+| ECS Fargate (embedding: 1 vCPU/3GB, llama.cpp) | ~$40 |
 | NAT Gateway | ~$32 |
 | ALB | ~$16 |
 | RDS (existing) | ~$13 |
@@ -766,6 +776,31 @@ docker exec nearby-admin-backend-1 python scripts/manage_users.py list
 
 ---
 
+## Embedding / Semantic Search
+
+Semantic + hybrid search use **EmbeddingGemma** (768-dim) through a shared, fail-soft HTTP client (`shared/embeddings/client.py`). The model is served **out-of-process** — never bundled in the app image — and the SERVER differs per environment while the client code is identical (it speaks one of two wire protocols, selected by `EMBEDDING_BACKEND`).
+
+| Environment | Server | `EMBEDDING_BACKEND` | `EMBEDDING_SERVICE_URL` | Model |
+|---|---|---|---|---|
+| **Local (Mac/PC)** | Docker Model Runner (GGUF, native — the amd64 TEI image crashes under emulation on Apple Silicon) | `openai` | `http://model-runner.docker.internal/engines/v1` | `ai/embeddinggemma` (`docker model pull ai/embeddinggemma`) |
+| **Prod (cloud)** | llama.cpp `:server` on Fargate (Service Connect, internal) | `openai` | `http://embedding:80/v1` | unsloth `embeddinggemma-300M-Q8_0.gguf` |
+| **Tests** | deterministic mock client (no network, no torch) | — | unset | hashed 768-vec |
+
+If `EMBEDDING_SERVICE_URL` is unset the client is **disabled** and every call returns `None` with no network I/O → search degrades to keyword. The gemma prompt prefixes (`task: search result | query: ` / `title: none | text: `) are applied by the client.
+
+**Why not TEI in prod:** TEI's CPU/Candle backend crash-loops on EmbeddingGemma's Gemma3 dense/matryoshka layers (`Intel MKL ERROR ... SGEMM`); the ungated ONNX export lacks pooling/dense config. llama.cpp serves the GGUF cleanly.
+
+**Prod gotchas (each silently breaks embedding — all fixed in terraform):**
+- **Service Connect resolves the SHORT name only** (`embedding`), not the FQDN — the namespace is an HTTP (not private-DNS) namespace. URL is `http://embedding:80/v1`.
+- **The ECS SG self-ingress must be INLINE** in `aws_security_group.ecs` (`self = true`). A separate `aws_security_group_rule` conflicts with the SG's inline blocks and is silently wiped on every SG apply → embedding becomes unreachable.
+- The embedding port mapping needs **`appProtocol = "http"`** (else SC's Envoy resets connections). Changing it on a live SC service is immutable → `terraform apply -replace=module.ecs.aws_ecs_service.embedding`.
+- **Never hardcode the embedding task IP** — it changes on every redeploy. App/admin reach it by Service Connect name; one-off tasks must fetch the current IP.
+- Deploys are safe: CI uses `aws ecs update-service --force-new-deployment`, which re-pulls `:latest` into the EXISTING terraform task defs, preserving all `EMBEDDING_*` env. **CI does not run terraform.**
+
+**Backfill existing rows** (one-time; new/edited POIs self-embed via admin embed-on-write): run `nearby-admin/backend/scripts/backfill_embeddings.py` as an ECS `run-task` on the admin task def with a `command` override, `EMBEDDING_SERVICE_URL` pointed at the embedding task's current private IP (`http://<ip>:80/v1`, `EMBEDDING_BACKEND=openai`), and **`--batch-size 1`** (llama.cpp on 1 vCPU returns 504 on larger batches; the live single-doc path is unaffected). Populating the derived `embedding` column this way is the sanctioned exception to the "never modify prod data" rule — it is index data, not user content.
+
+---
+
 ## Known Issues & Solutions
 
 ### Docker DNS Collision (CRITICAL)
@@ -820,25 +855,21 @@ server: {
 
 ### pgvector / Embedding Column
 
-**Problem**: The `nearby-app` SQLAlchemy model defines an `embedding` column using pgvector, but:
-- Local dev database doesn't have pgvector extension installed
-- Production may or may not have the embedding column yet
-- SQLAlchemy includes ALL model columns in SELECT queries, causing failures
+Semantic search is **live in prod** (EmbeddingGemma via llama.cpp — see "Embedding / Semantic Search" above). Don't regress it:
 
-**Solution**:
-1. Remove `embedding` from the SQLAlchemy ORM model (`nearby-app/backend/app/models/poi.py`)
-2. Check for column existence at runtime in search functions
-3. Fall back to keyword search when embedding is unavailable
+- The `embedding vector(768)` column exists in prod via migration `k_embedding_001` (pgvector extension + HNSW index). It is **populated** by admin embed-on-write and the one-time backfill, and **read** by the app's hybrid/semantic search.
+- The column is **intentionally NOT mapped on the `nearby-app` SQLAlchemy ORM**. If it were, every `SELECT *` would emit the vector and fail where pgvector is absent (older local DBs). The search path reads/writes it via **raw SQL**, gated on column existence, with a keyword fallback if the column OR the embedding service is unavailable.
+- Local dev: the embedding model is served by Docker Model Runner (see the per-environment table above), not bundled in the app image.
 
 ```python
-# Check if embedding column exists before using it
+# Search still gates on column existence and falls back to keyword if absent:
 from sqlalchemy import text
 result = db.execute(text(
     "SELECT column_name FROM information_schema.columns "
     "WHERE table_name = 'points_of_interest' AND column_name = 'embedding'"
 )).fetchone()
 if not result:
-    return search_pois(db, query)  # Fallback to keyword search
+    return search_pois(db, query)  # keyword fallback
 ```
 
 ### Publication Status Filtering

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,12 @@ This rule ensures data integrity and prevents accidental modifications to live p
 
 ---
 
+## Run Only in Docker
+
+**Always run the apps, scripts, migrations, and tests inside Docker — never directly on the host** (no Python venv; only a partial `node_modules`).
+
+---
+
 ## Production Deployment (AWS ECS Fargate)
 
 Production runs on **AWS ECS Fargate** with fully automated CI/CD. There are no manual rebuilds or SSH sessions — push to `main` and it deploys automatically.

--- a/nearby-admin/backend/app/api/endpoints/utils.py
+++ b/nearby-admin/backend/app/api/endpoints/utils.py
@@ -8,8 +8,9 @@ Currently exposes:
   return the matching 3-word address. Admin-only.
 """
 from fastapi import APIRouter, HTTPException, Depends
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from typing import Optional
+import re
 import httpx
 
 from app.core.config import settings
@@ -17,9 +18,28 @@ from app.core.permissions import require_admin
 
 router = APIRouter(prefix="/utils", tags=["Utils"])
 
+# Three dot-separated lowercase words. The canonical form users copy/paste from
+# what3words.com is prefixed with "///" — we accept and strip it.
+_W3W_RE = re.compile(r'^[a-z]+\.[a-z]+\.[a-z]+$')
+
 
 class W3WIn(BaseModel):
-    words: str = Field(..., pattern=r'^[a-z]+\.[a-z]+\.[a-z]+$')
+    words: str
+
+    @field_validator('words', mode='before')
+    @classmethod
+    def _normalize_words(cls, v):
+        if not isinstance(v, str):
+            raise ValueError('what3words address must be a string')
+        # Strip the leading "///" (and any stray whitespace) before validating.
+        cleaned = v.strip().lstrip('/').strip()
+        if not _W3W_RE.match(cleaned):
+            raise ValueError(
+                'Invalid what3words address — expected three dot-separated '
+                'lowercase words, e.g. "filled.count.soap" or '
+                '"///filled.count.soap".'
+            )
+        return cleaned
 
 
 class CoordsIn(BaseModel):
@@ -33,6 +53,56 @@ class W3WOut(BaseModel):
     nearest_place: Optional[str] = None
     country: Optional[str] = None
     words: str
+
+
+def _raise_for_w3w(r: httpx.Response) -> dict:
+    """
+    Return the parsed JSON body of a successful what3words response, or raise a
+    descriptive HTTPException for an error response.
+
+    what3words signals errors via the HTTP status and/or an ``{"error": {...}}``
+    body, e.g. ``{"error": {"code": "QuotaExceeded", "message": "..."}}``. The
+    previous code collapsed every non-200 into an opaque "HTTP 502", which made
+    the Free-plan and bad-key cases impossible to diagnose from the admin UI.
+    """
+    try:
+        j = r.json()
+    except Exception:
+        j = {}
+
+    err = j.get("error") if isinstance(j, dict) else None
+    if r.status_code == 200 and not err:
+        return j if isinstance(j, dict) else {}
+
+    err_dict = err if isinstance(err, dict) else {}
+    code = err_dict.get("code")
+    message = err_dict.get("message")
+
+    if code == "QuotaExceeded":
+        # Free plan, or monthly quota exhausted: convert-to-coordinates and
+        # convert-to-3wa require a paid what3words plan.
+        raise HTTPException(
+            status_code=402,
+            detail="what3words: this API plan does not include coordinate "
+                   "conversion (or the quota is exhausted). Upgrade the plan at "
+                   "https://accounts.what3words.com/select-plan.",
+        )
+    if code in ("InvalidKey", "MissingKey"):
+        raise HTTPException(
+            status_code=502,
+            detail="what3words: the API key was rejected — check "
+                   "WHAT3WORDS_API_KEY (dev .env / prod SSM).",
+        )
+    if code in ("BadWords", "BadCoordinates", "BadInput", "BadLanguage", "NotFound"):
+        raise HTTPException(
+            status_code=400,
+            detail=message or f"what3words rejected the request ({code}).",
+        )
+
+    detail = f"what3words upstream error ({code or r.status_code})"
+    if message:
+        detail += f": {message}"
+    raise HTTPException(status_code=502, detail=detail)
 
 
 @router.post("/what3words-to-coords", response_model=W3WOut)
@@ -57,10 +127,7 @@ async def what3words_to_coords(
     except httpx.HTTPError as e:
         raise HTTPException(status_code=502, detail=f"what3words upstream error: {e}")
 
-    if r.status_code != 200:
-        raise HTTPException(status_code=502, detail=f"what3words returned {r.status_code}")
-
-    j = r.json()
+    j = _raise_for_w3w(r)
     coords = j.get("coordinates") or {}
     lat = coords.get("lat")
     lng = coords.get("lng")
@@ -102,10 +169,7 @@ async def coords_to_what3words(
     except httpx.HTTPError as e:
         raise HTTPException(status_code=502, detail=f"what3words upstream error: {e}")
 
-    if r.status_code != 200:
-        raise HTTPException(status_code=502, detail=f"what3words returned {r.status_code}")
-
-    j = r.json()
+    j = _raise_for_w3w(r)
     words = j.get("words")
     if not words:
         raise HTTPException(status_code=502, detail="what3words response missing words")

--- a/nearby-admin/backend/app/crud/crud_poi.py
+++ b/nearby-admin/backend/app/crud/crud_poi.py
@@ -371,11 +371,12 @@ def create_poi(db: Session, poi: schemas.PointOfInterestCreate):
             is_main=True
         ))
 
-    # Validate free business category limit
+    # Validate free business category limit. Only a FREE BUSINESS is capped at one
+    # category; paid business and every other POI type may have multiple.
     if poi.category_ids:
-        poi_type_str = poi.poi_type if isinstance(poi.poi_type, str) else poi.poi_type
+        poi_type_str = poi.poi_type.value if hasattr(poi.poi_type, 'value') else str(poi.poi_type)
         listing_type = poi_data.get('listing_type', 'free')
-        if listing_type == 'free' and poi_type_str == 'BUSINESS' and len(poi.category_ids) > 1:
+        if poi_type_str == 'BUSINESS' and listing_type == 'free' and len(poi.category_ids) > 1:
             raise HTTPException(status_code=400, detail="Free business listings are limited to 1 category")
 
     # Add secondary categories via poi_categories table with is_main=False.
@@ -606,9 +607,16 @@ def update_poi(db: Session, *, db_obj: models.PointOfInterest, obj_in: schemas.P
     if 'category_ids' in update_data:
         category_ids = update_data.pop('category_ids')
 
-        # Validate free business category limit
+        # Validate free business category limit. Evaluate the poi_type / listing_type
+        # being SAVED in this request (falling back to the stored values), NOT the
+        # stale stored type — otherwise changing a free business into a park/trail/
+        # event, or upgrading it to a paid tier, in the same save is wrongly blocked
+        # by the old type. Only a FREE BUSINESS is capped at one category; paid
+        # business and every other POI type may have multiple.
+        effective_type = update_data.get('poi_type', poi_type_str)
+        effective_type = effective_type.value if hasattr(effective_type, 'value') else str(effective_type)
         listing_type = update_data.get('listing_type', getattr(db_obj, 'listing_type', 'free'))
-        if listing_type == 'free' and poi_type_str == 'BUSINESS' and len(category_ids) > 1:
+        if effective_type == 'BUSINESS' and listing_type == 'free' and len(category_ids) > 1:
             raise HTTPException(status_code=400, detail="Free business listings are limited to 1 category")
 
         from app.models.category import poi_category_association

--- a/nearby-admin/backend/app/schemas/poi.py
+++ b/nearby-admin/backend/app/schemas/poi.py
@@ -447,7 +447,11 @@ class PointOfInterestBase(EmptyStringToNoneMixin, BaseModel):
     admin_notes: Optional[str] = None
     accessible_parking_details: Optional[List[str]] = None
     accessible_restroom: Optional[bool] = False
-    accessible_restroom_details: Optional[Dict[str, Any]] = None
+    # Current shape is a list of checklist labels (like accessible_parking_details /
+    # playground_ada_checklist); legacy rows may still hold the old {label: bool}
+    # dict. Accept BOTH so the admin list response never fails validation — a strict
+    # Dict here 500s the whole /api/admin/pois/ list on any list-shaped row.
+    accessible_restroom_details: Optional[Union[List[str], Dict[str, Any]]] = None
     playground_age_groups: Optional[List[str]] = None
     playground_ada_checklist: Optional[List[str]] = None
     inclusive_playground: Optional[bool] = False
@@ -768,7 +772,11 @@ class PointOfInterestUpdate(EmptyStringToNoneMixin, BaseModel):
     admin_notes: Optional[str] = None
     accessible_parking_details: Optional[List[str]] = None
     accessible_restroom: Optional[bool] = None
-    accessible_restroom_details: Optional[Dict[str, Any]] = None
+    # Current shape is a list of checklist labels (like accessible_parking_details /
+    # playground_ada_checklist); legacy rows may still hold the old {label: bool}
+    # dict. Accept BOTH so the admin list response never fails validation — a strict
+    # Dict here 500s the whole /api/admin/pois/ list on any list-shaped row.
+    accessible_restroom_details: Optional[Union[List[str], Dict[str, Any]]] = None
     playground_age_groups: Optional[List[str]] = None
     playground_ada_checklist: Optional[List[str]] = None
     inclusive_playground: Optional[bool] = None

--- a/nearby-admin/frontend/src/components/POIForm/components/CoordinateInput.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/components/CoordinateInput.jsx
@@ -12,8 +12,12 @@ import { notifications } from '@mantine/notifications';
 import { IconMapPin, IconWorld } from '@tabler/icons-react';
 import { api } from '../../../utils/api';
 
-// Same regex the backend enforces for what3words on /api/utils/what3words-to-coords
-const W3W_PATTERN = /^[a-z]+\.[a-z]+\.[a-z]+$/;
+// Same shape the backend enforces for what3words on /api/utils/what3words-to-coords.
+// Accepts the canonical "///word.word.word" users copy/paste from what3words.com
+// as well as the bare "word.word.word" form; the "///" is stripped before use.
+const W3W_PATTERN = /^(?:\/\/\/)?[a-z]+\.[a-z]+\.[a-z]+$/;
+const stripW3WPrefix = (s) =>
+  (typeof s === 'string' ? s.trim().replace(/^\/+/, '').trim() : '');
 
 /**
  * <CoordinateInput>
@@ -66,7 +70,7 @@ export default function CoordinateInput({
     setBusy(true);
     try {
       const resp = await api.post('/utils/what3words-to-coords', {
-        words: w3w.trim(),
+        words: stripW3WPrefix(w3w),
       });
       if (!resp.ok) {
         const body = await resp.json().catch(() => ({}));
@@ -149,10 +153,15 @@ export default function CoordinateInput({
 
       <TextInput
         label="what3words Address"
-        placeholder="word1.word2.word3"
-        description='Three lowercase words separated by dots, e.g. "filled.count.soap"'
+        placeholder="///filled.count.soap"
+        description='Three lowercase words separated by dots. The "///" prefix copied from what3words.com is accepted.'
         value={w3w}
         onChange={(e) => emit({ w3w: e.currentTarget.value })}
+        onBlur={() => {
+          const cleaned = stripW3WPrefix(w3w);
+          if (cleaned !== w3w) emit({ w3w: cleaned });
+        }}
+        error={w3w && !w3wValid ? 'Enter three dot-separated words, e.g. filled.count.soap' : null}
         disabled={disabled}
       />
 

--- a/nearby-admin/frontend/src/components/POIForm/constants/initialValues.js
+++ b/nearby-admin/frontend/src/components/POIForm/constants/initialValues.js
@@ -19,7 +19,7 @@ export const emptyInitialValues = {
   address_city: 'Pittsboro',
   address_state: 'NC',
   address_zip: '',
-  address_county: 'Chatham',
+  address_county: 'Chatham County',
   // Front door coordinates
   front_door_latitude: null,
   front_door_longitude: null,

--- a/nearby-admin/frontend/src/components/POIForm/constants/validationRules.js
+++ b/nearby-admin/frontend/src/components/POIForm/constants/validationRules.js
@@ -1,4 +1,4 @@
-import { getLegacyFieldsForListingType, PARKING_OPTIONS } from '../../../utils/constants';
+import { PARKING_OPTIONS } from '../../../utils/constants';
 
 // First PARKING_OPTIONS entry is the "Accessible Parking" option whose selection
 // reveals — and now requires — the ADA accessible-parking sub-checklist.
@@ -41,13 +41,17 @@ export const getValidationRules = () => ({
   address_state: (value) => (!value ? 'State is required' : null),
   main_category_id: (value) => (!value ? 'Main category is required' : null),
   category_ids: (value, values) => {
-    // Secondary categories are optional for all POI types
-    if (values?.poi_type === 'BUSINESS') {
-      return null;
+    // Rule: only a FREE BUSINESS is limited to a single category. Paid business
+    // and every other POI type (park / trail / event) may have multiple. Mirrors
+    // the backend check in crud_poi.py so the limit shows inline instead of
+    // surfacing as a save-time 400.
+    const isFreeBusiness =
+      values?.poi_type === 'BUSINESS' &&
+      (values?.listing_type === 'free' || !values?.listing_type);
+    if (isFreeBusiness && (value?.length || 0) > 1) {
+      return 'Free business listings are limited to 1 category';
     }
-    const fieldConfig = getLegacyFieldsForListingType(values?.listing_type, values?.poi_type);
-    const maxCategories = fieldConfig?.maxCategories || 3;
-    return value?.length > maxCategories ? `Maximum ${maxCategories} categories allowed` : null;
+    return null;
   },
   'event.start_datetime': (value, values) => {
     if (values?.poi_type === 'EVENT' && !value) {

--- a/nearby-admin/frontend/src/components/POIForm/layouts/BusinessFreeLayout.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/layouts/BusinessFreeLayout.jsx
@@ -17,7 +17,7 @@ import { RestroomLocationGroup } from '../components/RestroomLocationGroup';
 import { FeaturedImageUpload, shouldUseImageUpload } from '../ImageIntegration';
 
 import ServiceAnimalAlert from '../components/ServiceAnimalAlert';
-import { AdminOnlyAccordionItem, IdealForGrouped } from './_shared';
+import { AdminOnlyAccordionItem, IdealForGrouped, FeaturedIdealForChips } from './_shared';
 import {
   getFieldsForListingType, PRICE_RANGE_OPTIONS,
   PARKING_OPTIONS, PARKING_ADA_CHECKLIST,
@@ -91,6 +91,8 @@ export default function BusinessFreeLayout({ form, userRole, poiId }) {
           <Stack>
             <CategoriesSection form={form} isFreeListing isPaidListing={false} />
             <IdealForGrouped form={form} listingType="Business Free" totalCap={fields.maxIdealFor} />
+            <Divider my="sm" />
+            <FeaturedIdealForChips form={form} />
           </Stack>
         </Accordion.Panel>
       </Accordion.Item>

--- a/nearby-admin/frontend/src/components/POIForm/layouts/BusinessPaidLayout.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/layouts/BusinessPaidLayout.jsx
@@ -24,7 +24,7 @@ import { RestroomLocationGroup } from '../components/RestroomLocationGroup';
 import { PayphoneLocationGroup } from '../components/PayphoneLocationGroup';
 import ServiceAnimalAlert from '../components/ServiceAnimalAlert';
 import {
-  AdminOnlyAccordionItem, IdealForGrouped, FullAmenitiesBlock,
+  AdminOnlyAccordionItem, IdealForGrouped, FeaturedIdealForChips, FullAmenitiesBlock,
   ArrivalMethodsGroup, PAYMENT_METHODS, DISCOUNT_TYPES,
 } from './_shared';
 import {
@@ -84,6 +84,8 @@ export default function BusinessPaidLayout({ form, userRole, poiId }) {
             <CategoriesSection form={form} isPaidListing isFreeListing={false} />
             <Divider my="sm" />
             <IdealForGrouped form={form} listingType="Business Paid" />
+            <Divider my="sm" />
+            <FeaturedIdealForChips form={form} />
           </Stack>
         </Accordion.Panel>
       </Accordion.Item>

--- a/nearby-admin/frontend/src/components/POIForm/layouts/EventLayout.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/layouts/EventLayout.jsx
@@ -30,7 +30,7 @@ import { FeaturedImageUpload, shouldUseImageUpload } from '../ImageIntegration';
 
 import ServiceAnimalAlert from '../components/ServiceAnimalAlert';
 import {
-  AdminOnlyAccordionItem, IdealForGrouped, ArrivalMethodsGroup,
+  AdminOnlyAccordionItem, IdealForGrouped, FeaturedIdealForChips, ArrivalMethodsGroup,
   FullAmenitiesBlock,
 } from './_shared';
 import {
@@ -104,6 +104,8 @@ export default function EventLayout({ form, userRole, poiId }) {
             <CategoriesSection form={form} isPaidListing isFreeListing={false} />
             <Divider my="sm" />
             <IdealForGrouped form={form} listingType="Event" />
+            <Divider my="sm" />
+            <FeaturedIdealForChips form={form} />
           </Stack>
         </Accordion.Panel>
       </Accordion.Item>

--- a/nearby-admin/frontend/src/components/POIForm/layouts/ParkLayout.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/layouts/ParkLayout.jsx
@@ -79,8 +79,8 @@ export default function ParkLayout({ form, userRole, poiId }) {
         </Accordion.Panel>
       </Accordion.Item>
 
-      {/* 2. Categories + Discovery — ADD Ideal For (5 groups) + Key Ideal For
-              (Featured chips render inside CategoriesSection). */}
+      {/* 2. Categories + Discovery — Ideal For (5 groups). Parks do NOT get the
+              "Featured Ideal For" top-3 picker (Business + Event only). */}
       <Accordion.Item value="s2-categories">
         <Accordion.Control><Text fw={600}>Categories + Discovery</Text></Accordion.Control>
         <Accordion.Panel>

--- a/nearby-admin/frontend/src/components/POIForm/layouts/TrailLayout.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/layouts/TrailLayout.jsx
@@ -184,8 +184,8 @@ export default function TrailLayout({ form, userRole, poiId }) {
         </Accordion.Panel>
       </Accordion.Item>
 
-      {/* 3. Categories + Discovery — ADD Ideal For (5 groups) + Key Ideal For
-              (Featured chips render inside CategoriesSection). */}
+      {/* 3. Categories + Discovery — Ideal For (5 groups). Trails do NOT get the
+              "Featured Ideal For" top-3 picker (Business + Event only). */}
       <Accordion.Item value="s3-categories">
         <Accordion.Control><Text fw={600}>Categories + Discovery</Text></Accordion.Control>
         <Accordion.Panel>

--- a/nearby-admin/frontend/src/components/POIForm/layouts/__tests__/BusinessFreeLayout.test.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/layouts/__tests__/BusinessFreeLayout.test.jsx
@@ -60,6 +60,7 @@ vi.mock('../_shared', () => ({
     </Accordion.Item>
   ),
   IdealForGrouped: () => <div data-testid="stub-ideal-for" />,
+  FeaturedIdealForChips: () => <div data-testid="stub-featured-ideal-for" />,
 }));
 
 import BusinessFreeLayout from '../BusinessFreeLayout';

--- a/nearby-admin/frontend/src/components/POIForm/layouts/__tests__/BusinessPaidLayout.test.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/layouts/__tests__/BusinessPaidLayout.test.jsx
@@ -79,6 +79,7 @@ vi.mock('../_shared', () => ({
     </Accordion.Item>
   ),
   IdealForGrouped: () => <div data-testid="stub-ideal-for" />,
+  FeaturedIdealForChips: () => <div data-testid="stub-featured-ideal-for" />,
   FullAmenitiesBlock: () => <div data-testid="stub-amenities-block" />,
   ArrivalMethodsGroup: () => <div data-testid="stub-arrival-methods" />,
   PAYMENT_METHODS: [],

--- a/nearby-admin/frontend/src/components/POIForm/layouts/__tests__/EventLayout.test.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/layouts/__tests__/EventLayout.test.jsx
@@ -81,6 +81,7 @@ vi.mock('../_shared', () => ({
     </Accordion.Item>
   ),
   IdealForGrouped: () => <div data-testid="stub-ideal-for" />,
+  FeaturedIdealForChips: () => <div data-testid="stub-featured-ideal-for" />,
   FullAmenitiesBlock: () => <div data-testid="stub-amenities-block" />,
   ConnectivityRow: () => <div data-testid="stub-connectivity" />,
   ArrivalMethodsGroup: () => <div data-testid="stub-arrival" />,

--- a/nearby-admin/frontend/src/components/POIForm/layouts/__tests__/FeaturedIdealForChips.test.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/layouts/__tests__/FeaturedIdealForChips.test.jsx
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { FeaturedIdealForChips } from '../_shared';
+
+// jsdom polyfill — Mantine v8 components touch ResizeObserver.
+if (typeof window !== 'undefined' && !window.ResizeObserver) {
+  window.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+// Harness wires a real @mantine/form so setFieldValue persists between clicks,
+// and dumps ideal_for_key so assertions can read the stored value.
+function Harness({ initialIdealFor = {}, initialKey = [] }) {
+  const form = useForm({
+    initialValues: {
+      ideal_for: {
+        atmosphere: [], age_group: [], social_settings: [],
+        local_special: [], special_needs: [],
+        ...initialIdealFor,
+      },
+      ideal_for_key: initialKey,
+    },
+  });
+  return (
+    <MantineProvider>
+      <FeaturedIdealForChips form={form} />
+      <div data-testid="key-dump">{JSON.stringify(form.values.ideal_for_key)}</div>
+      <button
+        data-testid="uncheck-A"
+        onClick={() =>
+          form.setFieldValue(
+            'ideal_for.atmosphere',
+            (form.values.ideal_for.atmosphere || []).filter((v) => v !== 'A'),
+          )
+        }
+      >
+        uncheck A
+      </button>
+    </MantineProvider>
+  );
+}
+
+const dump = () => screen.getByTestId('key-dump').textContent;
+
+describe('FeaturedIdealForChips (Featured / Key Ideal For top-3 picker)', () => {
+  it('shows the placeholder when nothing is checked above', () => {
+    render(<Harness />);
+    expect(screen.getByTestId('featured-ideal-for-empty')).toHaveTextContent(
+      /Select some Ideal For items above to populate this list\./,
+    );
+    expect(screen.queryByTestId('featured-ideal-for-counter')).not.toBeInTheDocument();
+  });
+
+  it('renders one chip per checked trait, unioned across groups', () => {
+    render(
+      <Harness initialIdealFor={{ atmosphere: ['A', 'B'], age_group: ['C'] }} />,
+    );
+    expect(screen.getByTestId('featured-chip-A')).toBeInTheDocument();
+    expect(screen.getByTestId('featured-chip-B')).toBeInTheDocument();
+    expect(screen.getByTestId('featured-chip-C')).toBeInTheDocument();
+    expect(screen.getByTestId('featured-ideal-for-counter')).toHaveTextContent('0 / 3 featured');
+  });
+
+  it('features a trait into ideal_for_key on click', () => {
+    render(<Harness initialIdealFor={{ atmosphere: ['A', 'B'] }} />);
+    fireEvent.click(screen.getByTestId('featured-chip-A'));
+    expect(dump()).toBe(JSON.stringify(['A']));
+    expect(screen.getByTestId('featured-chip-A')).toHaveAttribute('data-selected', 'true');
+    expect(screen.getByTestId('featured-ideal-for-counter')).toHaveTextContent('1 / 3 featured');
+  });
+
+  it('un-features on a second click', () => {
+    render(<Harness initialIdealFor={{ atmosphere: ['A'] }} initialKey={['A']} />);
+    expect(dump()).toBe(JSON.stringify(['A']));
+    fireEvent.click(screen.getByTestId('featured-chip-A'));
+    expect(dump()).toBe(JSON.stringify([]));
+  });
+
+  it('enforces the 3-item cap and locks remaining chips', () => {
+    render(
+      <Harness
+        initialIdealFor={{ atmosphere: ['A', 'B', 'C', 'D'] }}
+        initialKey={['A', 'B', 'C']}
+      />,
+    );
+    expect(screen.getByTestId('featured-ideal-for-counter')).toHaveTextContent('3 / 3 featured');
+    const fourth = screen.getByTestId('featured-chip-D');
+    expect(fourth).toHaveAttribute('aria-disabled', 'true');
+    // Clicking the locked 4th chip must NOT add it.
+    fireEvent.click(fourth);
+    expect(dump()).toBe(JSON.stringify(['A', 'B', 'C']));
+  });
+
+  it('prunes featured items that are no longer checked above (on mount)', () => {
+    render(<Harness initialIdealFor={{ atmosphere: ['A'] }} initialKey={['A', 'Z']} />);
+    // 'Z' was never a checked trait -> dropped from ideal_for_key.
+    expect(dump()).toBe(JSON.stringify(['A']));
+  });
+
+  it('prunes a featured item when it is unchecked above (live)', () => {
+    render(<Harness initialIdealFor={{ atmosphere: ['A', 'B'] }} initialKey={['A']} />);
+    expect(dump()).toBe(JSON.stringify(['A']));
+    fireEvent.click(screen.getByTestId('uncheck-A'));
+    expect(dump()).toBe(JSON.stringify([]));
+  });
+});

--- a/nearby-admin/frontend/src/components/POIForm/layouts/__tests__/IdealForGrouped.test.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/layouts/__tests__/IdealForGrouped.test.jsx
@@ -75,9 +75,10 @@ describe('IdealForGrouped (Issue #43 unified checkbox grid)', () => {
     expect(screen.queryByTestId('ideal-for-cap-counter')).not.toBeInTheDocument();
   });
 
-  // #76/#77 — Ideal For + Key Ideal For are now enabled for Park & Trail
+  // #76/#77 — the Ideal For checkbox GROUPS are enabled for Park & Trail
   // (IDEAL_FOR_RULES.Park/Trail visible:true). Previously these asserted the
   // groups were hidden; the foundation pass intentionally reversed that.
+  // (The separate "Featured Ideal For" top-3 picker is Business + Event only.)
   it('renders all 5 groups when listingType="Park" (#76 enables Ideal For)', () => {
     render(<TestWrapper listingType="Park" />);
     expectAllGroupsPresent();

--- a/nearby-admin/frontend/src/components/POIForm/layouts/_shared.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/layouts/_shared.jsx
@@ -198,27 +198,118 @@ export function IdealForGrouped({ form, listingType, totalCap = null }) {
 }
 
 // -----------------------------------------------------------------------------
-// Featured Ideal For — read-only chip display of currently-selected ideal_for
-// items (across all 5 groups). Replaces the old flat "Key Ideal For" checkbox
-// block in CategoriesSection.
+// Featured Ideal For (a.k.a. "Key Ideal For") — interactive top-3 picker.
+//
+// Renders AFTER the IdealForGrouped checkboxes (bottom of the section). The
+// admin checks Ideal-For traits above; those checked traits surface here as
+// clickable chips. Clicking a chip features it (writes it into
+// `form.values.ideal_for_key`); the public app shows up to `cap` (3) of these
+// prominently on the listing card.
+//
+// Rules:
+//   - Candidates = the union of every checked ideal_for group (no separate
+//     option list — it always mirrors what's checked above).
+//   - `ideal_for_key` is kept a strict SUBSET of the checked traits: anything
+//     unchecked above is pruned here automatically.
+//   - Hard cap of `cap` (default 3) featured for every POI type that shows this
+//     control; once the cap is hit, unselected chips lock out.
+//   - Empty state shows the populate-me placeholder.
+//
+// NOT rendered for Park/Trail (those layouts simply don't include it).
 // -----------------------------------------------------------------------------
-export function FeaturedIdealForChips({ form }) {
+export function FeaturedIdealForChips({ form, cap = 3 }) {
   const current = form.values.ideal_for || {};
-  const selected = IDEAL_FOR_GROUPS.flatMap(g => (Array.isArray(current[g.key]) ? current[g.key] : []));
+
+  // Union of all checked traits, in group/option order, deduped.
+  const candidates = [];
+  const checkedSet = new Set();
+  for (const g of IDEAL_FOR_GROUPS) {
+    const list = Array.isArray(current[g.key]) ? current[g.key] : [];
+    for (const opt of list) {
+      if (!checkedSet.has(opt)) { checkedSet.add(opt); candidates.push(opt); }
+    }
+  }
+
+  const stored = Array.isArray(form.values.ideal_for_key) ? form.values.ideal_for_key : [];
+  // Render only featured items that are still checked above (defensive against
+  // legacy `ideal_for_key` rows that predate this subset rule).
+  const selected = stored.filter((v) => checkedSet.has(v));
+
+  // Persist the prune so the saved value never drifts from what's checked.
+  const candidatesKey = candidates.join(' ');
+  useEffect(() => {
+    if (selected.length !== stored.length) {
+      form.setFieldValue('ideal_for_key', selected);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [candidatesKey]);
+
+  const atCap = cap != null && selected.length >= cap;
+
+  const toggle = (name) => {
+    if (selected.includes(name)) {
+      form.setFieldValue('ideal_for_key', selected.filter((v) => v !== name));
+    } else if (!atCap) {
+      form.setFieldValue('ideal_for_key', [...selected, name]);
+    }
+  };
+
   return (
-    <Stack gap="xs">
+    <Stack gap="xs" data-testid="featured-ideal-for">
       <Title order={5}>Featured Ideal For</Title>
       <Text size="sm" c="dimmed">
-        Items currently selected in the Ideal For section above.
+        Pick up to {cap} of your selected Ideal For traits to feature on the
+        listing card. Only items checked above appear here.
       </Text>
-      {selected.length === 0 ? (
-        <Text size="sm" c="dimmed" fs="italic">None selected yet.</Text>
+      {candidates.length === 0 ? (
+        <Text size="sm" c="dimmed" fs="italic" data-testid="featured-ideal-for-empty">
+          Select some Ideal For items above to populate this list.
+        </Text>
       ) : (
-        <Group gap="xs">
-          {selected.map((v) => (
-            <Badge key={v} variant="light" color="blue">{v}</Badge>
-          ))}
-        </Group>
+        <>
+          <Group gap="xs">
+            {candidates.map((name) => {
+              const isOn = selected.includes(name);
+              const locked = !isOn && atCap;
+              return (
+                <Badge
+                  key={name}
+                  variant={isOn ? 'filled' : 'outline'}
+                  color={isOn ? 'grape' : 'gray'}
+                  size="lg"
+                  role="button"
+                  tabIndex={locked ? -1 : 0}
+                  aria-pressed={isOn}
+                  aria-disabled={locked}
+                  data-testid={`featured-chip-${name}`}
+                  data-selected={isOn ? 'true' : 'false'}
+                  style={{
+                    cursor: locked ? 'not-allowed' : 'pointer',
+                    opacity: locked ? 0.45 : 1,
+                    textTransform: 'none',
+                  }}
+                  onClick={() => { if (!locked) toggle(name); }}
+                  onKeyDown={(e) => {
+                    if (locked) return;
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      toggle(name);
+                    }
+                  }}
+                >
+                  {name}
+                </Badge>
+              );
+            })}
+          </Group>
+          <Text
+            size="xs"
+            c={atCap ? 'orange' : 'dimmed'}
+            data-testid="featured-ideal-for-counter"
+          >
+            {selected.length} / {cap} featured on listing card
+          </Text>
+        </>
       )}
     </Stack>
   );

--- a/nearby-admin/frontend/src/components/POIForm/layouts/_shared.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/layouts/_shared.jsx
@@ -566,7 +566,11 @@ function PlaygroundRowExtras({ form, fieldName, idx, isPark = false, id = null }
   };
 
   const updateAdaCategory = (catKey, vals) => {
-    form.setFieldValue(`${fieldName}.${idx}.ada_checklist.${catKey}`, vals);
+    // Write the whole ada_checklist object (not a deeper `.${catKey}` path):
+    // Mantine's setPath does NOT create missing intermediate objects, so a
+    // freshly-added playground row (no `ada_checklist` key) would silently drop
+    // the write and the checkboxes would appear unresponsive (#84).
+    form.setFieldValue(`${fieldName}.${idx}.ada_checklist`, { ...adaChecklist, [catKey]: vals });
   };
 
   return (

--- a/nearby-admin/frontend/src/components/POIForm/sections/CategoriesSection.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/sections/CategoriesSection.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import {
-  Stack, Alert, Divider, Text
+  Stack, Alert, Text
 } from '@mantine/core';
 import { MainCategorySelector } from '../../MainCategorySelector';
 import { TreeCategorySelector } from '../../TreeCategorySelector';
 import { PrimaryTypeSelector } from '../../PrimaryTypeSelector';
 import { getLegacyFieldsForListingType as getFieldsForListingType } from '../../../utils/constants';
-import { FeaturedIdealForChips } from '../layouts/_shared';
 
 export const CategoriesSection = React.memo(function CategoriesSection({
   form,
@@ -55,12 +54,9 @@ export const CategoriesSection = React.memo(function CategoriesSection({
         </Alert>
       )}
 
-      {/* Issue #43: Featured Ideal For chips (read-only, surfaces what's
-          selected in IdealForGrouped). The old flat 75-checkbox "Key Ideal For"
-          block and the legacy <IdealForSelector /> stack are removed.
-          IdealForGrouped is rendered by the layout, not here. */}
-      <Divider my="md" label="Featured Ideal For" />
-      <FeaturedIdealForChips form={form} />
+      {/* Featured Ideal For (the "Key Ideal For" top-3 picker) now renders in
+          each layout AFTER IdealForGrouped — see FeaturedIdealForChips in
+          _shared.jsx. It is intentionally NOT here, and NOT on Park/Trail. */}
     </Stack>
   );
 });

--- a/nearby-admin/frontend/src/components/POIForm/sections/CoreInformationSection.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/sections/CoreInformationSection.jsx
@@ -5,7 +5,7 @@ import {
 import RichTextEditor from '../../RichTextEditor';
 import { DebouncedTextInput } from '../../DebouncedTextInput';
 import { getDebouncedInputProps } from '../constants/helpers';
-import { getStatusOptions } from '../../../utils/constants'; // KEY_FACILITIES removed (Migration A #34)
+import { getStatusOptions, LISTING_TYPES } from '../../../utils/constants'; // KEY_FACILITIES removed (Migration A #34)
 import {
   FeaturedImageUpload,
   shouldUseImageUpload
@@ -36,18 +36,17 @@ export const CoreInformationSection = React.memo(function CoreInformationSection
           ]}
           {...form.getInputProps('poi_type')}
         />
+        {/* Listing Type is the BILLING TIER only (free / paid / paid_founding /
+            community_comped) — these are the only values the backend schema +
+            DB CHECK constraint accept. "Sponsor" is a SEPARATE, orthogonal flag
+            set ONLY by the admin-only Sponsor toggle (is_sponsor + sponsor_level)
+            in the Admin Only accordion (see _shared.jsx AdminOnlyAccordionItem).
+            The old sponsor_* listing_type values were retired in migration
+            p1_001_phase1_additive. */}
         <Select
           label="Listing Type"
           placeholder="Select Listing Type"
-          data={[
-            { value: 'free', label: 'Free' },
-            { value: 'paid', label: 'Paid' },
-            { value: 'sponsor_platform', label: 'Sponsor – Platform' },
-            { value: 'sponsor_state', label: 'Sponsor – State' },
-            { value: 'sponsor_county', label: 'Sponsor – County' },
-            { value: 'sponsor_town', label: 'Sponsor – Town' },
-            { value: 'community_comped', label: 'Community Comped' }
-          ]}
+          data={LISTING_TYPES}
           {...form.getInputProps('listing_type')}
         />
       </SimpleGrid>

--- a/nearby-admin/frontend/src/components/POIForm/sections/LocationSection.jsx
+++ b/nearby-admin/frontend/src/components/POIForm/sections/LocationSection.jsx
@@ -1,6 +1,6 @@
 import React, { lazy, Suspense } from 'react';
 import {
-  Stack, SimpleGrid, Select, NumberInput, Button, Divider,
+  Stack, SimpleGrid, Select, Autocomplete, NumberInput, Button, Divider,
   Checkbox, Radio, Card, Group, ActionIcon, Alert, Text, TextInput, Switch
 } from '@mantine/core';
 import { IconPlus, IconTrash, IconMapPin, IconInfoCircle } from '@tabler/icons-react';
@@ -90,10 +90,15 @@ export const LocationSection = React.memo(function LocationSection({
           nothingFoundMessage="Type to enter a custom city"
           {...form.getInputProps('address_city')}
         />
-        <DebouncedTextInput
+        <Autocomplete
           label="County"
-          placeholder="County name"
-          {...getDebouncedInputProps(form, 'address_county')}
+          placeholder="Start typing a county..."
+          data={[
+            'Chatham County', 'Randolph County', 'Lee County', 'Wake County',
+            'Orange County', 'Durham County', 'Alamance County', 'Moore County',
+            'Harnett County', 'Guilford County'
+          ]}
+          {...form.getInputProps('address_county')}
         />
         <Select
           label="State"

--- a/nearby-app/app/src/data/poi_fields.json
+++ b/nearby-app/app/src/data/poi_fields.json
@@ -1234,7 +1234,7 @@
       "VOLUNTEER_OPPORTUNITIES",
       "DISASTER_HUBS"
     ],
-    "tier": "paid",
+    "tier": "any",
     "audience": "public",
     "render": "auto",
     "icon": null,

--- a/scripts/gen_poi_registry.py
+++ b/scripts/gen_poi_registry.py
@@ -506,7 +506,10 @@ DEPRECATED = {
 PAID_FIELDS = {
     "history_paragraph", "community_impact", "article_links",
     "organization_memberships", "locally_found_at", "service_locations",
-    "ideal_for", "ideal_for_key", "gallery_photos",
+    # ``ideal_for_key`` (the curated "Featured Ideal For" subset) is deliberately
+    # tier "any", NOT paid: free listings also pick up to 3 featured traits, so
+    # the public API must emit it for free POIs too. The app decides display.
+    "ideal_for", "gallery_photos",
     "business_amenities", "youth_amenities", "entertainment_options",
     "menu_photos", "menu_link", "delivery_links", "reservation_links",
     "appointment_links", "online_ordering_links",

--- a/shared/poi_fields.json
+++ b/shared/poi_fields.json
@@ -1234,7 +1234,7 @@
       "VOLUNTEER_OPPORTUNITIES",
       "DISASTER_HUBS"
     ],
-    "tier": "paid",
+    "tier": "any",
     "audience": "public",
     "render": "auto",
     "icon": null,

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -112,7 +112,10 @@ module "ecs" {
   admin_backend_image  = "${local.ecr_base}/nearbynearby/nearby-admin-backend:latest"
   admin_frontend_image = "${local.ecr_base}/nearbynearby/nearby-admin-frontend:latest"
 
-  # Embedding service: ECR mirror of ghcr.io/huggingface/text-embeddings-inference:cpu-1.8.1
+  # Embedding server: ECR mirror of ghcr.io/ggml-org/llama.cpp:server, serving the
+  # ungated unsloth EmbeddingGemma Q8_0 GGUF via its OpenAI-compatible endpoint.
+  # (TEI was the original plan but its CPU/Candle backend crashes on EmbeddingGemma's
+  # Gemma3 dense layers — Intel MKL SGEMM error — so we run llama.cpp instead.)
   embedding_image = "${local.ecr_base}/nearbynearby/embedding:${var.embedding_image_tag}"
 
   # Existing S3 & CloudFront (not managed by Terraform)
@@ -132,9 +135,12 @@ module "ecs" {
   admin_log_group_name     = module.monitoring.admin_log_group_name
   embedding_log_group_name = module.monitoring.embedding_log_group_name
 
-  # Internal embedding service (Service Connect)
+  # Internal embedding service (Service Connect). The namespace is an HTTP
+  # (not private-DNS) namespace, so SC only makes the short client_alias dns_name
+  # ("embedding") resolvable via its proxy — the FQDN does NOT resolve. /v1 base
+  # for the OpenAI-compatible llama.cpp endpoint (client appends /embeddings).
+  embedding_service_url     = "http://embedding:80/v1"
   service_connect_namespace = var.service_connect_namespace
-  embedding_service_url     = "http://embedding.${var.service_connect_namespace}:80"
 
   # GitHub Actions OIDC (provider already exists in this account)
   create_github_oidc       = false

--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -8,6 +8,9 @@ aws_account_id = "487615743990"
 s3_bucket_name    = "nearbynearby-prod-images"
 cloudfront_domain = "d24ow80agebvkk.cloudfront.net"
 
+# Embedding server image tag (ECR mirror of ghcr.io/ggml-org/llama.cpp:server)
+embedding_image_tag = "llamacpp-server"
+
 # VPC Peering (ECS VPC → default VPC where existing RDS lives)
 default_vpc_id             = "vpc-0bd0c59269a9c6591"
 default_vpc_route_table_id = "rtb-09ac44ef39d3a69ae"

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -112,6 +112,9 @@ resource "aws_ecs_task_definition" "app" {
         { name = "AWS_REGION", value = var.aws_region },
         { name = "ALLOWED_ORIGINS", value = var.app_allowed_origins },
         { name = "EMBEDDING_SERVICE_URL", value = var.embedding_service_url },
+        { name = "EMBEDDING_BACKEND", value = "openai" },
+        { name = "EMBEDDING_MODEL", value = "embeddinggemma" },
+        { name = "EMBEDDING_TIMEOUT", value = "30" },
       ]
 
       secrets = [
@@ -261,6 +264,9 @@ resource "aws_ecs_task_definition" "admin" {
         { name = "ALLOWED_ORIGINS", value = var.admin_allowed_origins },
         { name = "PRODUCTION_DOMAIN", value = var.admin_domain },
         { name = "EMBEDDING_SERVICE_URL", value = var.embedding_service_url },
+        { name = "EMBEDDING_BACKEND", value = "openai" },
+        { name = "EMBEDDING_MODEL", value = "embeddinggemma" },
+        { name = "EMBEDDING_TIMEOUT", value = "30" },
       ]
 
       secrets = [
@@ -407,13 +413,25 @@ resource "aws_ecs_task_definition" "embedding" {
       image     = var.embedding_image
       essential = true
 
-      # TEI serves on port 80; "embedding" is the Service Connect port name.
-      command = ["--model-id", var.embedding_model_id, "--port", "80"]
+      # llama.cpp server: serve the ungated EmbeddingGemma Q8_0 GGUF and expose
+      # the OpenAI-compatible /v1/embeddings endpoint. --host 0.0.0.0 is required
+      # so Service Connect peers can reach it; -ub/-c sized so a full-length doc
+      # embeds in one pass. "embedding" is the Service Connect port name (80).
+      command = [
+        "--hf-repo", "unsloth/embeddinggemma-300m-GGUF",
+        "--hf-file", "embeddinggemma-300M-Q8_0.gguf",
+        "--embeddings", "--host", "0.0.0.0", "--port", "80",
+        "-c", "2048", "-ub", "2048", "-b", "2048",
+      ]
 
       portMappings = [{
         name          = "embedding"
         containerPort = 80
         protocol      = "tcp"
+        # appProtocol is required for Service Connect to set up a proper L7 (HTTP)
+        # proxy; without it SC falls back to a TCP listener that resets the
+        # app/admin client connections before they reach llama.cpp.
+        appProtocol = "http"
       }]
 
       # No container-level healthCheck: the minimal HF text-embeddings-inference

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -152,6 +152,19 @@ resource "aws_security_group" "ecs" {
     security_groups = [aws_security_group.alb.id]
   }
 
+  # Intra-ECS traffic between tasks in this SG: Service Connect Envoy proxying
+  # AND direct internal services (the embedding server on :80). Declared INLINE
+  # with self=true so it belongs to this SG's authoritative rule set. A separate
+  # aws_security_group_rule conflicts with these inline blocks and gets silently
+  # wiped on every SG apply — which is exactly what left embedding unreachable.
+  ingress {
+    description = "All traffic between ECS tasks (self)"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    self        = true
+  }
+
   egress {
     from_port   = 0
     to_port     = 0
@@ -162,19 +175,6 @@ resource "aws_security_group" "ecs" {
   tags = { Name = "${var.project}-${var.environment}-ecs-sg" }
 
   lifecycle { create_before_destroy = true }
-}
-
-# Self-referencing rule so ECS tasks (app/admin) can reach the internal
-# embedding service on the TEI port (80) over Service Connect / private DNS.
-# Declared separately to avoid a self-reference cycle inside the SG block.
-resource "aws_security_group_rule" "ecs_internal_embedding" {
-  type                     = "ingress"
-  description              = "TEI embedding service (port 80) from ECS tasks"
-  from_port                = 80
-  to_port                  = 80
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.ecs.id
-  source_security_group_id = aws_security_group.ecs.id
 }
 
 resource "aws_security_group" "rds" {

--- a/tests/test_phase1_what3words.py
+++ b/tests/test_phase1_what3words.py
@@ -32,12 +32,58 @@ class TestWhat3Words:
         assert body["country"] == "GB"
         assert body["words"] == "filled.count.soap"
 
+    def test_slash_prefix_is_accepted_and_stripped(self, admin_client, httpx_mock, w3w_key):
+        # Users paste the canonical "///word.word.word" from what3words.com; the
+        # backend must accept it and call the API with the bare form (issue #80).
+        httpx_mock.add_response(
+            url="https://api.what3words.com/v3/convert-to-coordinates?words=filled.count.soap&key=test-key",
+            json={
+                "coordinates": {"lat": 51.5, "lng": -0.19},
+                "words": "filled.count.soap",
+            },
+        )
+        resp = admin_client.post(
+            "/api/utils/what3words-to-coords",
+            json={"words": "///filled.count.soap"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["words"] == "filled.count.soap"
+
     def test_malformed_words_returns_400(self, admin_client, w3w_key):
         resp = admin_client.post(
             "/api/utils/what3words-to-coords",
             json={"words": "abc"},
         )
         assert resp.status_code == 422 or resp.status_code == 400
+
+    def test_quota_exceeded_returns_402_with_upgrade_hint(self, admin_client, httpx_mock, w3w_key):
+        # Free plan / exhausted quota -> 402 QuotaExceeded. Surface a clear,
+        # actionable message instead of an opaque 502 (issue #80, bugs #1/#3).
+        httpx_mock.add_response(
+            url="https://api.what3words.com/v3/convert-to-coordinates?words=filled.count.soap&key=test-key",
+            status_code=402,
+            json={"error": {"code": "QuotaExceeded", "message": "Quota exceeded or API plan does not have access to this feature."}},
+        )
+        resp = admin_client.post(
+            "/api/utils/what3words-to-coords",
+            json={"words": "filled.count.soap"},
+        )
+        assert resp.status_code == 402, resp.text
+        detail = resp.json()["detail"].lower()
+        assert "plan" in detail and "upgrade" in detail
+
+    def test_invalid_key_returns_502_with_key_hint(self, admin_client, httpx_mock, w3w_key):
+        httpx_mock.add_response(
+            url="https://api.what3words.com/v3/convert-to-coordinates?words=filled.count.soap&key=test-key",
+            status_code=401,
+            json={"error": {"code": "InvalidKey", "message": "Authentication failed; invalid API key"}},
+        )
+        resp = admin_client.post(
+            "/api/utils/what3words-to-coords",
+            json={"words": "filled.count.soap"},
+        )
+        assert resp.status_code == 502, resp.text
+        assert "key" in resp.json()["detail"].lower()
 
     def test_missing_api_key_returns_503(self, admin_client, monkeypatch):
         monkeypatch.setattr(settings, "what3words_api_key", None)


### PR DESCRIPTION
Ships all outstanding work on \`fix/post-release-followups\` to prod (10 commits ahead of main; main's 2 extra commits are no-op merge commits, so this is a clean superset — no regressions, no conflicts).

## Highlights
- **fix(admin): accessible_restroom_details list shape** — resolves the live prod outage where GET /api/admin/pois/ 500s (ResponseValidationError) and blanks the admin POI list. Schema now accepts the current list shape + legacy dict.
- **fix(admin/poi-form): category cap by the type being saved** — free business = 1 category; paid business + all other types = multiple; no longer blocked by the stale stored type on edit.
- **feat(admin): Featured Ideal For top-3 picker**, playground ADA checklist fix (#84), ///-prefixed what3words (#80), county free-text autocomplete, sponsor/listing-type cleanup.
- docs + terraform (embedding via llama.cpp) — terraform already applied to prod; CI does not run terraform (no-op here).

## Safety
- ✅ No new DB migrations.
- ✅ No regression: branch is a content superset of origin/main.
- Triggers deploy-admin (no test gate) and deploy-app (registry regen only; may gate on the known-red app suite — admin deploys independently).