### PR TITLE
Green the integration suite + main-category PUT fix (enables clean deploy-app)

### DIFF
--- a/nearby-admin/backend/app/crud/crud_poi.py
+++ b/nearby-admin/backend/app/crud/crud_poi.py
@@ -568,20 +568,20 @@ def update_poi(db: Session, *, db_obj: models.PointOfInterest, obj_in: schemas.P
             if not main_category:
                 raise HTTPException(status_code=400, detail="Invalid main category")
 
-            # Determine the effective category membership for validation.
+            # Enforce "main ∈ selected" ONLY when category_ids is being set in THIS
+            # request (consistency check, mirroring the create path). A main-only
+            # update is allowed to introduce a NEW main category — it is added to the
+            # membership as is_main=True in the block below — so it must not be
+            # rejected for not already being a selected category. (Issue #42 was
+            # over-strict here: it 422'd every partial {"main_category_id": ...} PUT,
+            # contradicting the very insert logic that follows.)
             if 'category_ids' in update_data:
                 effective_category_ids = set(update_data.get('category_ids') or [])
-            else:
-                existing_rows = db.execute(poi_category_association.select().where(
-                    poi_category_association.c.poi_id == db_obj.id
-                )).fetchall()
-                effective_category_ids = {row.category_id for row in existing_rows}
-
-            if effective_category_ids and main_category_id not in effective_category_ids:
-                raise HTTPException(
-                    status_code=422,
-                    detail="main_category_id must be one of the POI's selected category_ids",
-                )
+                if effective_category_ids and main_category_id not in effective_category_ids:
+                    raise HTTPException(
+                        status_code=422,
+                        detail="main_category_id must be one of the POI's selected category_ids",
+                    )
 
             # Check if this category already exists for this POI
             existing = db.execute(poi_category_association.select().where(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,11 @@ TEST_DATABASE_URL = os.environ.get(
 
 # Admin backend settings
 os.environ.setdefault("DATABASE_URL", TEST_DATABASE_URL)
+# Admin's TestSettings fallback (nearby-admin core/config.py) reads TEST_DATABASE_URL
+# and otherwise defaults to an in-Docker "test-db" host that is unresolvable when the
+# suite runs on the host (CI + local). Point it at the same DB so the admin
+# embed-on-write path (which opens its OWN SessionLocal) connects correctly.
+os.environ.setdefault("TEST_DATABASE_URL", TEST_DATABASE_URL)
 os.environ.setdefault("SECRET_KEY", "test-secret-key-for-integration-tests-minimum-32-characters-long")
 os.environ.setdefault("ENVIRONMENT", "development")
 os.environ.setdefault("TESTING", "true")

--- a/tests/test_event_backend_tasks.py
+++ b/tests/test_event_backend_tasks.py
@@ -301,8 +301,8 @@ class TestEventSponsors:
             event={
                 "start_datetime": "2026-12-01T10:00:00Z",
                 "sponsors": [
-                    {"name": "Acme Corp", "url": "https://acme.com"},
-                    {"name": "Local Bank", "url": "https://localbank.com"},
+                    {"name": "Acme Corp", "url": "https://acme.com", "tier": "Tier 1"},
+                    {"name": "Local Bank", "url": "https://localbank.com", "tier": "Tier 2"},
                 ],
             },
         )
@@ -319,7 +319,7 @@ class TestEventSponsors:
             json={
                 "event": {
                     "sponsors": [
-                        {"name": "New Sponsor", "url": "https://newsponsor.com"},
+                        {"name": "New Sponsor", "url": "https://newsponsor.com", "tier": "Tier 1"},
                     ],
                 },
             },
@@ -745,7 +745,7 @@ class TestAllNewFieldsRoundtrip:
                     {"name": "GA", "url": "https://tickets.com/ga"},
                 ],
                 "sponsors": [
-                    {"name": "Sponsor A", "url": "https://sponsora.com"},
+                    {"name": "Sponsor A", "url": "https://sponsora.com", "tier": "Tier 1"},
                 ],
             },
         }

--- a/tests/test_event_lifecycle.py
+++ b/tests/test_event_lifecycle.py
@@ -607,7 +607,11 @@ class TestEventEndpoints:
 
     def test_by_type_event(self, db_session, app_client):
         """GET /api/pois/by-type/EVENT returns only events."""
-        orm_create_event(db_session, name="Type Filter Event", published=True)
+        # Use a future date so the by-type endpoint's default past-event filter
+        # keeps it (orm_create_event's hardcoded default date has drifted past).
+        future = datetime.now(timezone.utc) + timedelta(days=365)
+        orm_create_event(db_session, name="Type Filter Event", published=True,
+                         event_fields={"start_datetime": future})
         orm_create_business(db_session, name="Not An Event", published=True)
         db_session.commit()
 

--- a/tests/test_phase1_computed.py
+++ b/tests/test_phase1_computed.py
@@ -20,9 +20,12 @@ def test_icon_free_wifi_from_wifi_options():
 
 
 def test_icon_pet_friendly_toggle():
-    assert compute_icon_booleans({"pet_options": ["No Dogs Allowed"]})["icon_pet_friendly"] is False
-    assert compute_icon_booleans({"pet_options": ["Dog Friendly"]})["icon_pet_friendly"] is True
+    # Issue #48: pet_options no longer contains negative items, so ANY non-empty
+    # selection means pet friendly; empty/absent means not.
+    assert compute_icon_booleans({"pet_options": ["Dogs Allowed"]})["icon_pet_friendly"] is True
+    assert compute_icon_booleans({"pet_options": ["Cats Allowed"]})["icon_pet_friendly"] is True
     assert compute_icon_booleans({"pet_options": []})["icon_pet_friendly"] is False
+    assert compute_icon_booleans({})["icon_pet_friendly"] is False
 
 
 def test_icon_public_restroom_toggle():

--- a/tests/test_phase3_holiday_hours_consolidated.py
+++ b/tests/test_phase3_holiday_hours_consolidated.py
@@ -120,10 +120,12 @@ class TestHolidayHoursBackfillSQL:
         # clause's "no holidays key" branch hits).
         db_session.execute(text("""
             INSERT INTO points_of_interest
-                (id, name, location, hours, holiday_hours)
+                (id, name, poi_type, publication_status, location, hours, holiday_hours)
             VALUES (
                 gen_random_uuid(),
                 'Legacy Backfill POI #70',
+                'BUSINESS',
+                'draft',
                 ST_SetSRID(ST_MakePoint(-79, 36), 4326),
                 '{}'::jsonb,
                 '{"christmas": "closed"}'::jsonb


### PR DESCRIPTION
Makes the root integration suite fully green (557 passed, 2 xfailed, 0 failed locally) so deploy-app can run **without** skip_tests, plus one real admin fix.

## Code
- **fix(admin): main-category-only PUT** — `update_poi` 422'd a partial `{"main_category_id": ...}` PUT because it checked membership against existing categories even when `category_ids` wasn't in the request, contradicting the insert-new-main logic right below it. Now enforced only when `category_ids` is set in the same request.

## Tests / config (test-debt + env)
- **conftest**: export `TEST_DATABASE_URL` — admin's TestSettings fallback otherwise binds the embed-on-write `SessionLocal` to an unresolvable `test-db` host (fails in CI too) → fixes 3 `test_embedding_pipeline`.
- **sponsors (#51)**: add required `Tier` to sponsor payloads (3 tests).
- **test_by_type_event**: future `start_datetime` (default fixture date drifted past).
- **test_icon_pet_friendly_toggle**: assert #48 behavior (non-empty `pet_options` = friendly; removed the gone "No Dogs Allowed").
- **holiday backfill**: add NOT-NULL `poi_type` + `publication_status` to the raw INSERT.

Two of these (main-category, embedding DB host) would fail CI regardless; the rest are stale test data/dates.