### PR TITLE
fix(map): restore marker-click scroll-to-card + highlight (#108)

### DIFF
--- a/nearby-app/app/src/components/Map.jsx
+++ b/nearby-app/app/src/components/Map.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Popup, useMap, useMapEvents } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 
@@ -88,53 +88,49 @@ function AutoFitBounds({ bounds, radiusMiles }) {
  * visit starts fresh. pointerEvents:'none' ensures marker clicks are never blocked.
  */
 function ScrollWheelToggle() {
-  const map = useMap();
   const [active, setActive] = useState(false);
 
-  const activate = () => {
-    map.scrollWheelZoom.enable();
-    setActive(true);
-  };
+  // #108 fix: enable scroll-wheel zoom via Leaflet MAP events instead of a
+  // click-catching overlay. In Leaflet a marker click does NOT propagate to the
+  // map 'click', so numbered-marker clicks reach their handler again (scroll to
+  // card + highlight), while clicking the empty map still activates scroll zoom.
+  const map = useMapEvents({
+    click: () => { map.scrollWheelZoom.enable(); setActive(true); },
+    mouseout: () => { map.scrollWheelZoom.disable(); setActive(false); },
+  });
 
-  const deactivate = () => {
-    map.scrollWheelZoom.disable();
-    setActive(false);
-  };
-
+  // Hover hint only. This layer is pointerEvents:none so it NEVER intercepts
+  // marker or map clicks (that overlay was the cause of #108).
+  if (active) return null;
   return (
     <div
+      className="map-scroll-hint-layer"
       style={{
         position: 'absolute',
         inset: 0,
-        zIndex: 400,          // above tiles (200) and markers (300), below controls (1000)
-        pointerEvents: active ? 'none' : 'auto',
-        cursor: active ? 'default' : 'pointer',
+        zIndex: 400,
+        pointerEvents: 'none',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        background: active ? 'transparent' : 'rgba(0,0,0,0)',
       }}
-      onClick={activate}
-      onMouseLeave={deactivate}
       aria-hidden="true"
     >
-      {!active && (
-        <div
-          style={{
-            background: 'rgba(0,0,0,0.55)',
-            color: 'white',
-            padding: '6px 14px',
-            borderRadius: '4px',
-            fontSize: '13px',
-            fontWeight: 600,
-            pointerEvents: 'none',
-            opacity: 0,           // invisible by default; shown on hover via CSS
-          }}
-          className="map-scroll-hint"
-        >
-          Click map to enable scroll
-        </div>
-      )}
+      <div
+        className="map-scroll-hint"
+        style={{
+          background: 'rgba(0,0,0,0.55)',
+          color: 'white',
+          padding: '6px 14px',
+          borderRadius: '4px',
+          fontSize: '13px',
+          fontWeight: 600,
+          pointerEvents: 'none',
+          opacity: 0,           // shown on map hover via CSS
+        }}
+      >
+        Click map to enable scroll
+      </div>
     </div>
   );
 }

--- a/nearby-app/app/src/styles/app.scss
+++ b/nearby-app/app/src/styles/app.scss
@@ -8227,7 +8227,7 @@ input, button, textarea, select {
   opacity: 0;
   transition: opacity 0.2s ease;
 }
-:hover > .map-scroll-hint {
+.leaflet-container:hover .map-scroll-hint {
   opacity: 1;
 }
 


### PR DESCRIPTION
Fixes #108.

## Problem
Clicking a numbered map marker no longer scrolled to / highlighted its card — broken on both the Explore page and the Nearby section (both use the shared `Map`).

## Cause
`ScrollWheelToggle` (the "click map to enable scroll" overlay, #31) rendered a full-map transparent `<div>` at `z-index: 400` with `pointer-events: auto` while scroll-zoom was inactive (the default; resets on mouseout). It sat above the markers and ate the click, so `onMarkerClick` → scroll-to-card + highlight never fired.

## Fix
Enable scroll-wheel zoom via Leaflet **map events** (`click` enables, `mouseout` disables) instead of a click-catching overlay. In Leaflet a marker click does not propagate to the map `click`, so numbered-marker clicks reach their handler again while clicking the empty map still activates scroll zoom. The hover hint is kept but is now `pointer-events: none` so it can never block clicks.

## Verified
Marker click → scroll-to-card + highlight works on Explore and the Nearby section; scroll-wheel zoom still activates on map click; page scroll resumes on mouse-out.