### PR TITLE
fix(search): overlay removes suggestions (#114); home dropdown shows primary category (#126)

### DIFF
--- a/nearby-app/app/src/components/SearchBar.jsx
+++ b/nearby-app/app/src/components/SearchBar.jsx
@@ -12,6 +12,7 @@ const SearchBar = forwardRef(function SearchBar({
   onSearch = null,       // callback fired on Enter (no dropdown selection) or search button
   selectedType = null,   // optional POI type filter (e.g. "BUSINESS")
   initialQuery = '',     // pre-fill query
+  showSuggestions = true, // when false, no fuzzy dropdown — text entry + Enter/Search only (#114)
   inputId,
 }, ref) {
   const [searchQuery, setSearchQuery] = useState(initialQuery);
@@ -69,6 +70,8 @@ const SearchBar = forwardRef(function SearchBar({
   // filtered ids stay computed against the old, narrower set and the newly-in-
   // range matches would be wrongly hidden until the user re-typed.
   useEffect(() => {
+    // #114: overlay search passes showSuggestions=false — no fuzzy dropdown at all.
+    if (!showSuggestions) return;
     const delayDebounce = setTimeout(() => {
       if (searchQuery.trim().length > 0) {
         fetchSearchResults(searchQuery);
@@ -79,7 +82,7 @@ const SearchBar = forwardRef(function SearchBar({
     }, 300);
 
     return () => clearTimeout(delayDebounce);
-  }, [searchQuery, selectedType, nearbyPoiIds]);
+  }, [searchQuery, selectedType, nearbyPoiIds, showSuggestions]);
 
   const fetchSearchResults = async (query) => {
     setIsLoading(true);
@@ -191,7 +194,7 @@ const SearchBar = forwardRef(function SearchBar({
         />
       </div>
       <SearchDropdown
-        visible={showDropdown}
+        visible={showDropdown && showSuggestions}
         anchorEl={inputRef.current}
         isLoading={isLoading}
         results={searchResults}

--- a/nearby-app/app/src/components/SearchDropdown.jsx
+++ b/nearby-app/app/src/components/SearchDropdown.jsx
@@ -100,7 +100,9 @@ function SearchDropdown({
         <>
           <ul className="search-dropdown__list">
             {results.map((poi, index) => {
-              const typeLabel = TYPE_LABELS[poi.poi_type] || poi.poi_type;
+              // #126: show the POI's primary category (e.g. "Shopping & Retail");
+              // fall back to the generic type label when no main_category is set.
+              const badgeLabel = poi.main_category?.name || TYPE_LABELS[poi.poi_type] || poi.poi_type;
               return (
                 <li
                   key={poi.id}
@@ -112,7 +114,7 @@ function SearchDropdown({
                   <div className="search-dropdown__content">
                     <div className="search-dropdown__name-row">
                       <span className="search-dropdown__name">{poi.name}</span>
-                      <span className="search-dropdown__type-badge">{typeLabel}</span>
+                      <span className="search-dropdown__type-badge">{badgeLabel}</span>
                     </div>
                     {(poi.address_city || poi.address_state) && (
                       <div className="search-dropdown__city">

--- a/nearby-app/app/src/components/SearchOverlay.jsx
+++ b/nearby-app/app/src/components/SearchOverlay.jsx
@@ -57,6 +57,7 @@ export default function SearchOverlay({ isOpen, onClose, panelRef }) {
                 inputId="one_search"
                 placeholder="What's nearby? Search for locations or interests..."
                 onSearch={handleSearch}
+                showSuggestions={false}
               />
             </div>
             <button type="submit" className="button btn_search">Search</button>

--- a/nearby-app/app/src/styles/app.scss
+++ b/nearby-app/app/src/styles/app.scss
@@ -1560,11 +1560,14 @@ ul + h5 {
   justify-content: center;
   align-items: center;
 
+  .overlay_content {
+    min-width: 300px;
+  }
 }
 
 .nav_overlay_box {
-  width: 90%;
-  max-width: 800px;
+  width: 100%;
+  max-width: 100%;
   margin: 0 auto;
 
   @media (min-width: 1200px) {
@@ -8567,7 +8570,7 @@ $color_hint: #3c3c3c;
   padding: 12px 16px;
   border-top: 1px solid var(--gray-d);
   color: var(--nn-teal2);
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 600;
   cursor: pointer;
   transition: background 0.15s ease;


### PR DESCRIPTION
Resolves the previously-conflicting search issues by scoping each to its own search surface.

## #114 — Top-nav Search overlay: remove fuzzy suggestions
The full-screen Search overlay (opened from the nav Search button) no longer shows live suggestion results. The user types and hits **Enter** or the **Search** button to go to Explore.

- Added a `showSuggestions` prop to `SearchBar` (default `true`).
- `SearchOverlay` passes `showSuggestions={false}` → skips the debounced hybrid-search fetch and never renders `SearchDropdown`.
- Enter / Search button still routes to `/explore?q=…`.

## #126 — Home hero search: keep suggestions, show primary category
The home-page hero search dropdown is unchanged in behavior (suggestions stay), with two tweaks:

- **Badge = primary category.** The result badge now shows the POI's primary category (e.g. **"Shopping & Retail"** for *Pittsboro General Store*) instead of the generic type label ("Business"). `SearchDropdown` reads `poi.main_category.name` — already returned by the `hybrid-search` API — and falls back to the type label when absent. No backend change.
- **Bigger green text.** The "Search for '…' in Explore" footer text bumped 14px → 15px (Barry's `app.scss` tweak), plus his nav-overlay layout tweaks (`.overlay_content` min-width, `.nav_overlay_box` full width).

## Scope / notes
- The badge change lives in the shared `SearchDropdown`, so it also applies anywhere else the suggestion dropdown appears (Explore, Nearby) — a consistent improvement.
- Compiled `app.css` is not regenerated here (it's a VS Code Live Sass artifact); Vite compiles `app.scss` directly at build/runtime.

## Files
- `nearby-app/app/src/components/SearchBar.jsx`
- `nearby-app/app/src/components/SearchOverlay.jsx`
- `nearby-app/app/src/components/SearchDropdown.jsx`
- `nearby-app/app/src/styles/app.scss`
