### PR TITLE
fix(#138): mobile search/menu overlays close each other; fix focus ring

### DIFF
--- a/nearby-app/app/src/components/MobileNavBar.jsx
+++ b/nearby-app/app/src/components/MobileNavBar.jsx
@@ -11,7 +11,7 @@ export default function MobileNavBar({ searchOverlay, navOverlay }) {
         id="btn_search_nav"
         className={`btn_reset btn_trigger btn_nav_icon_style_1${searchOverlay.isOpen ? ' is_active' : ''}`}
         type="button"
-        onClick={searchOverlay.toggle}
+        onClick={() => { navOverlay.close(); searchOverlay.toggle(); }}
         aria-expanded={searchOverlay.isOpen}
         aria-controls="search_overlay"
         ref={searchOverlay.triggerRef}
@@ -34,7 +34,7 @@ export default function MobileNavBar({ searchOverlay, navOverlay }) {
         id="btn_overlay_navigation"
         className={`btn_reset btn_trigger btn_nav_icon_style_1${navOverlay.isOpen ? ' is_active' : ''}`}
         type="button"
-        onClick={navOverlay.toggle}
+        onClick={() => { searchOverlay.close(); navOverlay.toggle(); }}
         aria-expanded={navOverlay.isOpen}
         aria-controls="nav_overlay"
         ref={navOverlay.triggerRef}

--- a/nearby-app/app/src/hooks/useOverlay.js
+++ b/nearby-app/app/src/hooks/useOverlay.js
@@ -10,6 +10,7 @@ export default function useOverlay(id, { focusTargetId = null, skipDesktop = fal
   const [isOpen, setIsOpen] = useState(false);
   const panelRef = useRef(null);
   const triggerRef = useRef(null);
+  const hasOpenedRef = useRef(false); // stays false until first opened — prevents focusing the trigger on initial mount
 
   const open = useCallback(() => {
     if (skipDesktop && window.innerWidth >= 1200) return;
@@ -45,10 +46,13 @@ export default function useOverlay(id, { focusTargetId = null, skipDesktop = fal
   // Focus management
   useEffect(() => {
     if (!isOpen) {
-      // Restore focus to trigger on close
-      if (triggerRef.current) triggerRef.current.focus();
+      // Restore focus to the trigger on close — but ONLY after the overlay has
+      // been opened at least once. Otherwise this fires on the initial mount
+      // (isOpen starts false) and leaves a focus ring on the trigger by default.
+      if (hasOpenedRef.current && triggerRef.current) triggerRef.current.focus();
       return;
     }
+    hasOpenedRef.current = true;
 
     const timer = setTimeout(() => {
       if (focusTargetId) {

--- a/nearby-app/app/src/styles/app.scss
+++ b/nearby-app/app/src/styles/app.scss
@@ -1431,6 +1431,7 @@ ul + h5 {
   color: white;
   background-color: transparent !important;
   text-decoration: none !important;
+  border-radius: 3px !important;
   
   @media (min-width: 700px) {
     


### PR DESCRIPTION
## Problem
Two mobile nav bugs from #138:
1. Opening Search didn't close Menu and vice versa — both could be open simultaneously.
2. The mobile bottom-nav SEARCH button showed a default focus ring on page load, before ever being clicked.

## Fix
1. **Mutual exclusivity.** `MobileNavBar`'s Search and Menu buttons now close the opposite overlay before toggling their own, matching the pattern desktop's `Navbar` already used.
2. **Focus ring on load.** `useOverlay`'s focus-restore effect ran on initial mount (`isOpen` starts `false`), so it focused the trigger before the overlay was ever opened. Added a `hasOpenedRef` guard so focus only returns to the trigger after the overlay has actually been opened once. Fixes both overlays since it's the shared hook.

Also includes Barry's `border-radius: 3px !important` on `.btn_nav_icon_style_1` (the mobile Search/Menu buttons) — grouped here since it's the same component, not a generic style tweak.

## Files
- `nearby-app/app/src/components/MobileNavBar.jsx`
- `nearby-app/app/src/hooks/useOverlay.js`
- `nearby-app/app/src/styles/app.scss`
