### PR TITLE
CI: raise test-db max_connections for the full suite

### DIFF
--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -11,8 +11,10 @@ services:
       POSTGRES_DB: test_nearby
     # Every test drops/recreates the whole schema (40+ tables). With pytest-xdist
     # running many workers concurrently, the default max_locks_per_transaction=64
-    # overflows Postgres's shared lock table and errors the run.
-    command: postgres -c max_locks_per_transaction=256
+    # overflows Postgres's shared lock table and errors the run. The default
+    # max_connections=100 is likewise too low for the full suite under xdist
+    # (CI died with "sorry, too many clients already" at ~890 tests).
+    command: postgres -c max_locks_per_transaction=256 -c max_connections=300
     ports:
       - "5434:5432"
     healthcheck:


### PR DESCRIPTION
The deploy-app test job died at ~40% with Postgres 'sorry, too many clients already': the suite is now ~890 tests under pytest-xdist and the default max_connections=100 is too low. One line in tests/docker-compose.test.yml, same file CI boots the test database from. No app code changes.

https://claude.ai/code/session_01374LioK8cwTV21Zv4V9u7s